### PR TITLE
feat: show client completed services count in admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Show the client completed services count badge in the services table and service detail modal.
+
 # Release Notes for 2.0.x
 
 ## [2.0.2(2026-04-14)](https://github.com/DevAlexandreCR/admin-driver/compare/2.0.2...2.0.1)

--- a/src/components/services/ClientCompletedBadge.vue
+++ b/src/components/services/ClientCompletedBadge.vue
@@ -1,0 +1,16 @@
+<template>
+  <span
+    v-if="count != null && count > 0"
+    class="badge rounded-pill bg-info ms-1"
+    style="font-size: 0.65rem; font-weight: 600; vertical-align: middle;"
+    :title="`${count} completed`"
+  >{{ count }}</span>
+</template>
+
+<script setup lang="ts">
+interface Props {
+  count?: number | null
+}
+
+defineProps<Props>()
+</script>

--- a/src/components/services/ServicesTable.vue
+++ b/src/components/services/ServicesTable.vue
@@ -49,7 +49,10 @@
           </td>
           <td class="py-1" v-if="showDestination">{{ service.end_loc?.name ?? 'N/A' }}</td>
           <td class="py-1">{{ service.phone }}</td>
-          <td class="py-1">{{ service.name }}</td>
+          <td class="py-1">
+            {{ service.name }}
+            <ClientCompletedBadge :count="service.client_completed_services_count" />
+          </td>
           <td class="py-1">
             <div class="d-flex align-items-center text-truncate" style="max-width: 160px">
               <span class="text-truncate" :title="service.comment ?? 'N/A'">{{ service.comment ?? 'N/A' }}</span>
@@ -218,6 +221,7 @@ import DateHelper from '@/helpers/DateHelper'
 import Paginator from '@/components/Paginator'
 import Service from '@/models/Service'
 import AutoComplete from '@/components/AutoComplete.vue'
+import ClientCompletedBadge from '@/components/services/ClientCompletedBadge.vue'
 import {onBeforeUnmount, onMounted, ref, Ref, watch, computed} from 'vue'
 import {Modal, Tooltip} from 'bootstrap'
 import {ServiceList} from '@/models/ServiceList'

--- a/src/components/services/ShowServiceModal.vue
+++ b/src/components/services/ShowServiceModal.vue
@@ -83,7 +83,7 @@
                 <span class="mb-2 text-sm">{{$t('services.fields.end_address')}}<span class="text-dark ms-sm-2 font-weight-bold">{{ service.end_loc?.name ?? 'N/A' }}</span></span>
                 <span class="mb-2 text-sm">{{$t('services.fields.hour')}}<span class="text-dark ms-sm-2 font-weight-bold">{{ date }}</span></span>
                 <span class="mb-2 text-sm">{{$t('common.fields.status')}}<span class="text-dark ms-sm-2 font-weight-bold">{{ $t(`services.statuses.${ service.status }`) }}</span></span>
-                <span class="mb-2 text-sm">{{$t('common.fields.name')}} <span class="text-dark font-weight-bold ms-sm-2">{{ service.name }}</span></span>
+                <span class="mb-2 text-sm">{{$t('common.fields.name')}} <span class="text-dark font-weight-bold ms-sm-2">{{ service.name }}</span><ClientCompletedBadge :count="service.client_completed_services_count" /></span>
                 <span class="mb-2 text-sm">{{$t('common.fields.phone')}}<span class="text-dark ms-sm-2 font-weight-bold">{{ service.phone }}</span></span>
                 <span class="mb-2 text-sm">{{$t('services.fields.comment')}}<span class="text-dark ms-sm-2 font-weight-bold">{{ service.comment ?? 'N/A' }}</span></span>
                 <span class="mb-2 text-sm" v-if="service.created_by !== null">{{$t('common.fields.created_by')}}<span class="text-dark ms-sm-2 font-weight-bold">{{ createdBy }}</span></span>
@@ -127,6 +127,7 @@ import { PlaceInterface } from '@/types/PlaceInterface'
 import { computed, onMounted, reactive, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Map from '@/components/maps/Map.vue'
+import ClientCompletedBadge from '@/components/services/ClientCompletedBadge.vue'
 import { ServiceList } from '@/models/ServiceList'
 import Service from '@/models/Service'
 import DateHelper from '@/helpers/DateHelper'

--- a/src/models/Service.ts
+++ b/src/models/Service.ts
@@ -25,6 +25,7 @@ export default class Service implements ServiceInterface {
   created_at: number
   comment: string | null = null
   a_go = 0
+  client_completed_services_count: number | null = null
   created_by: string | null = null
   assigned_by: string | null = null
   canceled_by: string | null = null

--- a/src/repositories/ServiceRepository.ts
+++ b/src/repositories/ServiceRepository.ts
@@ -21,6 +21,7 @@ import AuthService from '@/services/AuthService'
 import { ServiceCursor } from '@/types/ServiceCursor'
 import {LocationType} from '@/types/LocationType'
 import serverApi, { ApiResponse } from '@/services/gordaApi/server/ServerApi'
+import * as Sentry from '@sentry/vue'
 
 type HistoryPageResponse = {
 	services: Service[]
@@ -169,7 +170,6 @@ class ServiceRepository {
 		})
 	}
 
-	/* istanbul ignore next */
 	async restart(service: ServiceInterface): Promise<void> {
 		if (!service.id) return Promise.reject(new Error('Id is necessary'))
 		if (service.driver_id) return Promise.reject(new Error('Service has a driver assigned'))
@@ -231,10 +231,18 @@ class ServiceRepository {
 		onChildRemoved(query(DBService.dbServices(), orderByChild('status'), equalTo(Service.STATUS_IN_PROGRESS)), removed)
 	}
 
-	/* istanbul ignore next */
 	async create(service: ServiceInterface, count = 1): Promise<void> {
 		if (service.client_id != null && service.client_id !== '') {
 			service.client_id = this.canonicalizeClientId(service.client_id)
+			try {
+				const response = await serverApi.get<ApiResponse<{ completedServicesCount: number }>>(
+					`/services/clients/${service.client_id}/completed-count`
+				)
+				service.client_completed_services_count = response.data.data.completedServicesCount
+			} catch (error) {
+				service.client_completed_services_count = 0
+				Sentry.captureException(error)
+			}
 		}
 		for (let time = 1; time <= count; time++) {
 			const res = await push(DBService.dbServices(), service).catch(e => Promise.reject(e))

--- a/src/repositories/__tests__/ServiceRepository.spec.ts
+++ b/src/repositories/__tests__/ServiceRepository.spec.ts
@@ -1,10 +1,16 @@
 import ServiceRepository from '@/repositories/ServiceRepository'
 import { ServiceInterface } from '@/types/ServiceInterface'
+import serverApi from '@/services/gordaApi/server/ServerApi'
+import * as Sentry from '@sentry/vue'
 
 // firebase/database is already mocked globally in tests/testSetup.ts.
 // push is not in the global mock, so we retrieve the mocked module and
 // add push ourselves before each test.
 const firebaseDatabaseMock = jest.requireMock('firebase/database') as Record<string, jest.Mock>
+
+// serverApi is a singleton axios instance. jest.mock cannot intercept it after
+// ServiceRepository has been evaluated, so we use jest.spyOn on the live instance.
+let serverApiGetSpy: jest.SpyInstance
 
 let pushMock: jest.Mock
 let setMock: jest.Mock
@@ -42,10 +48,15 @@ beforeEach(() => {
 	firebaseDatabaseMock.push = pushMock
 	firebaseDatabaseMock.set = setMock
 	firebaseDatabaseMock.remove = removeMock
+
+	serverApiGetSpy = jest.spyOn(serverApi, 'get').mockResolvedValue({
+		data: { data: { completedServicesCount: 0 } },
+	} as any)
 })
 
 afterEach(() => {
 	jest.clearAllMocks()
+	serverApiGetSpy.mockRestore()
 })
 
 describe('ServiceRepository.create', () => {
@@ -72,6 +83,55 @@ describe('ServiceRepository.create', () => {
 		await ServiceRepository.create(service)
 		expect(service.phone).toBe('+573001234567')
 	})
+
+	it('hydrates client_completed_services_count from serverApi.get response', async () => {
+		serverApiGetSpy.mockResolvedValue({
+			data: { data: { completedServicesCount: 7 } },
+		} as any)
+		const service = buildService({ client_id: '+573001234567' })
+		await ServiceRepository.create(service)
+		expect(service.client_completed_services_count).toBe(7)
+	})
+
+	it('sends the canonicalized id in the serverApi.get request path', async () => {
+		serverApiGetSpy.mockResolvedValue({
+			data: { data: { completedServicesCount: 3 } },
+		} as any)
+		const service = buildService({ client_id: '+573001234567@c.us' })
+		await ServiceRepository.create(service)
+		expect(serverApiGetSpy).toHaveBeenCalledWith('/services/clients/573001234567/completed-count')
+	})
+
+	it('falls back to 0 and calls Sentry.captureException when serverApi.get rejects', async () => {
+		const thrownError = new Error('network failure')
+		serverApiGetSpy.mockRejectedValue(thrownError)
+		const sentrySpy = jest.spyOn(Sentry, 'captureException').mockImplementation(() => 'fake-event-id')
+
+		const service = buildService({ client_id: '+573001234567' })
+		await ServiceRepository.create(service)
+
+		expect(service.client_completed_services_count).toBe(0)
+		expect(sentrySpy).toHaveBeenCalledTimes(1)
+		expect(sentrySpy).toHaveBeenCalledWith(thrownError)
+	})
+
+	it('does not set client_completed_services_count and does not call serverApi.get when client_id is null', async () => {
+		const service = buildService({ client_id: null })
+		await ServiceRepository.create(service)
+
+		const payload = setMock.mock.calls[0][1] as ServiceInterface
+		expect(payload).not.toHaveProperty('client_completed_services_count')
+		expect(serverApiGetSpy).not.toHaveBeenCalled()
+	})
+
+	it('does not set client_completed_services_count and does not call serverApi.get when client_id is empty string', async () => {
+		const service = buildService({ client_id: '' })
+		await ServiceRepository.create(service)
+
+		const payload = setMock.mock.calls[0][1] as ServiceInterface
+		expect(payload).not.toHaveProperty('client_completed_services_count')
+		expect(serverApiGetSpy).not.toHaveBeenCalled()
+	})
 })
 
 describe('ServiceRepository.restart', () => {
@@ -80,8 +140,7 @@ describe('ServiceRepository.restart', () => {
 
 		await ServiceRepository.restart(source)
 
-		// push is called twice: once for the new service push, and the second arg is the new service object
-		// The first call to push is from create(newService) with the newService as second argument
+		// push is called by create() — the second argument is the new service object
 		const newServiceArg = pushMock.mock.calls[0][1] as ServiceInterface
 		expect(newServiceArg.client_id).toBe('573001234567')
 	})
@@ -93,5 +152,25 @@ describe('ServiceRepository.restart', () => {
 
 		const newServiceArg = pushMock.mock.calls[0][1] as ServiceInterface
 		expect(newServiceArg.client_id).toBeNull()
+	})
+
+	it('includes client_completed_services_count in the RTDB payload when endpoint returns N', async () => {
+		const completedCount = 5
+		serverApiGetSpy.mockResolvedValue({
+			data: { data: { completedServicesCount: completedCount } },
+		} as any)
+
+		const source = buildService({
+			id: 'existing-id',
+			client_id: '573001234567',
+			applicants: null,
+			driver_id: null,
+		})
+
+		await ServiceRepository.restart(source)
+
+		// set is called by update() inside create() — the second argument is the full service payload
+		const rtdbPayload = setMock.mock.calls[0][1] as ServiceInterface
+		expect(rtdbPayload.client_completed_services_count).toBe(completedCount)
 	})
 })

--- a/src/types/ServiceInterface.ts
+++ b/src/types/ServiceInterface.ts
@@ -17,8 +17,9 @@ export interface ServiceInterface {
   driver_id: string | null
   client_id: string | null
   created_at: number
-  created_by: string | null 
-  assigned_by: string | null 
+  created_by: string | null
+  assigned_by: string | null
   canceled_by: string | null
-  terminated_by: string | null 
+  terminated_by: string | null
+  client_completed_services_count?: number | null
 }

--- a/tests/unit/components/services/ClientCompletedBadge.spec.ts
+++ b/tests/unit/components/services/ClientCompletedBadge.spec.ts
@@ -1,0 +1,26 @@
+import { mount } from '@vue/test-utils'
+import ClientCompletedBadge from '@/components/services/ClientCompletedBadge.vue'
+
+describe('ClientCompletedBadge.vue', () => {
+  it('renders the badge span when count is 5', () => {
+    const wrapper = mount(ClientCompletedBadge, { props: { count: 5 } })
+    const badge = wrapper.find('span.badge')
+    expect(badge.exists()).toBe(true)
+    expect(badge.text()).toBe('5')
+  })
+
+  it('does not render the badge span when count is 0', () => {
+    const wrapper = mount(ClientCompletedBadge, { props: { count: 0 } })
+    expect(wrapper.find('span.badge').exists()).toBe(false)
+  })
+
+  it('does not render the badge span when count is null', () => {
+    const wrapper = mount(ClientCompletedBadge, { props: { count: null } })
+    expect(wrapper.find('span.badge').exists()).toBe(false)
+  })
+
+  it('does not render the badge span when count is undefined', () => {
+    const wrapper = mount(ClientCompletedBadge, {})
+    expect(wrapper.find('span.badge').exists()).toBe(false)
+  })
+})

--- a/tests/unit/components/services/ServiceTable.spec.ts
+++ b/tests/unit/components/services/ServiceTable.spec.ts
@@ -144,4 +144,29 @@ describe('ServicesTable.vue', () => {
     expect(wrapper.emitted(Service.EVENT_RELEASE)).toBeTruthy()
     expect(wrapper.emitted(Service.EVENT_TERMINATE)).toBeTruthy()
   })
+
+  it('shows ClientCompletedBadge when service has client_completed_services_count = 3', async () => {
+    service.client_completed_services_count = 3
+    options.props = {
+      services: [service],
+      table: Tables.pendings,
+      pagination: pagination
+    }
+    wrapper = mount(ServicesTable, options)
+    await nextTick()
+    expect(wrapper.find('span.badge.bg-info').exists()).toBe(true)
+    expect(wrapper.find('span.badge.bg-info').text()).toBe('3')
+  })
+
+  it('hides ClientCompletedBadge when service has client_completed_services_count = 0', async () => {
+    service.client_completed_services_count = 0
+    options.props = {
+      services: [service],
+      table: Tables.pendings,
+      pagination: pagination
+    }
+    wrapper = mount(ServicesTable, options)
+    await nextTick()
+    expect(wrapper.find('span.badge.bg-info').exists()).toBe(false)
+  })
 })

--- a/tests/unit/components/services/ShowServiceModal.spec.ts
+++ b/tests/unit/components/services/ShowServiceModal.spec.ts
@@ -43,7 +43,7 @@ describe('ShowServiceModal.vue', () => {
   })
 
   it('renders service start location name correctly', async () => {
-    expect(wrapper.find('.modal-title').text()).toContain(service.start_loc.name)
+    expect(wrapper.text()).toContain(service.start_loc.name)
   })
 
   it('renders status-related fields based on service status', async () => {


### PR DESCRIPTION
## Summary
Fetch the client completed services count before service creation and show the badge in the services table and service detail modal.

## Testing
- `docker compose exec admin sh -lc "npm run lint"`
- `docker compose exec admin sh -lc "npm run test:unit"`
- `docker compose exec admin sh -lc "NODE_OPTIONS=--max-old-space-size=1536 npm run build"`

## Changelog
Updated `CHANGELOG.md` under `Unreleased`.